### PR TITLE
chore: add GitHub issue templates for bug reports and feature requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,31 @@
+---
+name: Bug Report
+about: Report a bug in PteroSim
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Description**
+A clear and concise description of what the bug is and the context in which you encountered it.
+Please include:
+ - Severity (blocked/slowed/inconvenienced):
+ - Reproduces (always/sometimes/rarely):
+ - Platform (Windows/Linux):
+ - PteroSim edition (Free/Edu/Pro):
+ - PteroSim version (release):
+ - Firmware (None/PX4 SITL/PX4 HITL/ArduPilot SITL/Betaflight/Manual):
+ - Stack trace:
+
+**To Reproduce**
+If possible, include steps to reproduce.
+
+**Logs**
+Please attach the latest log file from `Saved/Logs/PteroSim.log` and, if a crash occurred, the contents of `Saved/Crashes/` for the failed session.
+
+**Screenshots**
+If applicable, add screenshots or files to help explain the bug.
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,16 @@
+---
+name: Feature Request
+about: Request a feature in PteroSim
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Description**
+A clear and concise description of the feature you'd like.
+Please include:
+ - Urgency (blocked/slowed/inconvenienced):
+
+**Screenshots**
+If applicable, add screenshots or files to help explain the feature.


### PR DESCRIPTION
Adds bug-report.md and feature_request.md under .github/ISSUE_TEMPLATE/ to give users a structured way to report issues and request features.

Bug template captures: severity, reproducibility, platform, edition, version, firmware, stack trace, repro steps, logs and crashes paths.